### PR TITLE
Added shell parser to separate entry and args for command

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ var path = require('path');
 var server = require('socket.io');
 var pty = require('pty.js');
 var fs = require('fs');
+var shellquote = require('shell-quote');
 
 var opts = require('optimist')
     .options({
@@ -113,7 +114,9 @@ io.on('connection', function(socket){
 
     var term;
     if (process.getuid() == 0 || opts.command) {
-        term = pty.spawn(command, [], {
+        var args = shellquote.parse(command);
+        var entrypoint = args.shift();
+        term = pty.spawn(entrypoint, args, {
             name: 'xterm-256color',
             cols: 80,
             rows: 30

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
         "express": "3.5.1",
         "socket.io": "^1.3.7",
         "pty.js": "^0.3.0",
-        "optimist": "^0.6"
+        "optimist": "^0.6",
+        "shell-quote": "^1.4.3"
     },
     "devDependencies": {
         "load-grunt-tasks": "^3.0",


### PR DESCRIPTION
Tested with a somewhat strange `node app.js -c "/bin/bash -xc \"echo hello & /bin/bash\"" -p 80` and got the expected output:

```
+ /bin/bash
+ echo hello
hello
[root@fbffe09cdd9b wetty]# 
```
